### PR TITLE
feat: Update grpc-utils to 1.2.6

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,24 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="bin/main" path="src/main/java">
-		<attributes>
-			<attribute name="gradle_scope" value="main"/>
-			<attribute name="gradle_used_by_scope" value="main,test"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="bin/main" path="src/main/proto">
 		<attributes>
 			<attribute name="gradle_scope" value="main"/>
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/java">
-		<attributes>
-			<attribute name="gradle_scope" value="main"/>
-			<attribute name="gradle_used_by_scope" value="main,test"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/grpc">
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_scope" value="main"/>
 			<attribute name="gradle_used_by_scope" value="main,test"/>
@@ -36,6 +24,18 @@
 			<attribute name="gradle_scope" value="test"/>
 			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/grpc">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'visual-studio'
     id 'maven-publish'
 }
+
 group 'com.nikhilm'
 sourceCompatibility = 1.11
 def grpcVersion = '1.53.0'
@@ -124,9 +125,7 @@ dependencies {
     // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
 	implementation 'com.google.protobuf:protobuf-java:3.24.3'
 	implementation 'com.google.protobuf:protobuf-java-util:3.24.3'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
     //implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 	//implementation 'com.sun.xml.bind:jaxb-impl:3.0.0-M4'
 	//implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
@@ -134,7 +133,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"
-	implementation "${baseGroupId}:adempiere-grpc-utils:1.0.6"
+	implementation "${baseGroupId}:adempiere-grpc-utils:1.2.6"
 	//	Others
     compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/src/main/java/org/spin/template/grpc/client/TemplateClient.java
+++ b/src/main/java/org/spin/template/grpc/client/TemplateClient.java
@@ -29,7 +29,7 @@ import org.spin.proto.template_service.DeleteEntityRequest;
 import org.spin.proto.template_service.TemplateServiceGrpc;
 import org.spin.proto.template_service.TemplateServiceGrpc.TemplateServiceBlockingStub;
 import org.spin.service.grpc.authentication.TokenManager;
-import org.spin.service.grpc.util.ValueManager;
+import org.spin.service.grpc.util.value.ValueManager;
 import org.spin.template.setup.SetupLoader;
 
 import com.google.protobuf.Struct;

--- a/src/main/java/org/spin/template/service/Converter.java
+++ b/src/main/java/org/spin/template/service/Converter.java
@@ -19,7 +19,7 @@ import org.compiere.model.PO;
 import org.compiere.model.POInfo;
 import org.compiere.util.Env;
 import org.spin.proto.template_service.Entity;
-import org.spin.service.grpc.util.ValueManager;
+import org.spin.service.grpc.util.value.ValueManager;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;


### PR DESCRIPTION
Update `adempiere-grpc-utils` to 1.2.6 version, and remove JSON Web Token redundant dependencies.