### PR TITLE
feat: Upload `*.pb` descriptor as asset release.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,31 +39,31 @@ jobs:
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
 
       - name: Upload descriptor file artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-template-service.pb
           path: build/descriptors/adempiere-grpc-template-service.pb
 
       - name: Upload dist app zip artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-template-service.zip
           path: build/release/adempiere-grpc-template-service.zip
 
       - name: Upload dist app zip.MD5 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-template-service.zip.MD5
           path: build/release/adempiere-grpc-template-service.zip.MD5
 
       - name: Upload dist app tar artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-template-service.tar
           path: build/release/adempiere-grpc-template-service.tar
 
       - name: Upload dist app tar.MD5 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adempiere-grpc-template-service.tar.MD5
           path: build/release/adempiere-grpc-template-service.tar.MD5
@@ -77,7 +77,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+
+      - name: Upload Descriptor
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: adempiere-grpc-template-service.pb/adempiere-grpc-template-service.pb
 
       - name: Upload zip
         uses: skx/github-action-publish-binaries@master
@@ -106,6 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: adempiere-grpc-template-service.tar.MD5/adempiere-grpc-template-service.tar.MD5
+
 
 
   # Check secrets to push image in docker hub registry
@@ -143,7 +151,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Download build dist app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-template-service.zip
       - name: Unzip Asset
@@ -168,7 +176,7 @@ jobs:
   # TODO: Download .tar and add docker image without uncompress
   # Publish docker multiplatform image in Docker Hub Registry to application
   push-imame-dhr:
-    name: Push docker multiplatform image to Docker Hub
+    name: Push multiplatform docker image to Docker Hub
     needs:
       - check-docker-secrets
     # Skip step based on secret
@@ -178,7 +186,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       - name: Download build dist app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-template-service.zip
       - name: Unzip Asset
@@ -233,7 +241,7 @@ jobs:
   # TODO: Download .tar and add docker image without uncompress
   # Publish docker multiplatform image in Docker Hub Registry to application
   push-proxy-imame-dhr:
-    name: Push docker multiplatform image to Docker Hub
+    name: Push multiplatform proxy docker image to Docker Hub
     needs:
       - check-proxy-docker-secrets
     # Skip step based on secret
@@ -244,7 +252,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download descriptor app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adempiere-grpc-template-service.pb
           path: docker/
@@ -266,7 +274,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: docker/Dockerfile
+          file: docker/grpc_proxy.Dockerfile
           platforms: linux/amd64,linux/amd64/v2,linux/arm64/v8
           push: true
           tags: |


### PR DESCRIPTION
- Update `upload-artifact` action to version 4.
- Update `download-artifact` action to version 4.
- Upload `*.pb` descriptor as release asset.
- Fix build grp-proxy docker image.

![imagen](https://github.com/adempiere/adempiere-grpc-template-service/assets/20288327/adb1231f-9bb8-447e-9629-2e7ef246b2f0)

