### PR TITLE
fix: CI/CD Credentials with a secret.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ repositories {
 			// project property, system property, .env project file, system enviroment variable
 			username = findProperty("deployUsername") ?: System.properties['deploy.user'] ?:
 				projectEnv.get("GITHUB_DEPLOY_USER", null) ?: System.getenv("GITHUB_DEPLOY_USER")
-			password = findProperty("deployPassword") ?: System.properties['deploy.token'] ?:
+			password = findProperty("deployToken") ?: System.properties['deploy.token'] ?:
 				projectEnv.get("GITHUB_DEPLOY_TOKEN", null) ?: System.getenv("GITHUB_DEPLOY_TOKEN")
 		}
 	}
@@ -70,7 +70,7 @@ repositories {
 			// project property, system property, .env project file, system enviroment variable
 			username = findProperty("deployUsername") ?: System.properties['deploy.user'] ?:
 				projectEnv.get("GITHUB_DEPLOY_USER", null) ?: System.getenv("GITHUB_DEPLOY_USER")
-			password = findProperty("deployPassword") ?: System.properties['deploy.token'] ?:
+			password = findProperty("deployToken") ?: System.properties['deploy.token'] ?:
 				projectEnv.get("GITHUB_DEPLOY_TOKEN", null) ?: System.getenv("GITHUB_DEPLOY_TOKEN")
 		}
 	}


### PR DESCRIPTION
When config a repository/organization github secret as `DEPLOY_TOKEN`, this no set into gradle to maven credentials.

![imagen](https://github.com/user-attachments/assets/b5a1f28f-7802-43bc-8e7c-cbc416c59055)
